### PR TITLE
ci(workflows): use `build` and `uv` in cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
           parallel: true
           flag-name: run-${{ matrix.os }}-python-${{ matrix.python-version }}
 
+      - name: Install uv installer 🌞
+        run: pipx install uv
+
       - name: Build wheels 🛞
         uses: pypa/cibuildwheel@v2.20.0
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
 
       - name: Build wheels 🛞
         uses: pypa/cibuildwheel@v2.20.0
+        env:
+          CIBW_BUILD_FRONTEND: build[uv]
 
       - name: Upload wheel artifacts 🫖
         uses: actions/upload-artifact@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new environment variable for the frontend build process, enhancing the build configuration for packaging.
	- Added a step to install the `uv` package, ensuring necessary dependencies are available during the build.

- **Chores**
	- Updated the GitHub Actions workflow to improve the build process for frontend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->