### PR TITLE
ci(workflows): use sccache for caching rust deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Run sccache-cache 🗄️
+        uses: mozilla-actions/sccache-action@v0.0.5
+
       - name: Build sdist
         run: pipx run build --sdist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ defaults:
   run:
     shell: bash
 
+env:
+  # enable caching for faster compilation
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
 jobs:
   test:
     name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
@@ -38,6 +43,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
+      - name: Run sccache-cache 🗄️
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Setup Rust Cache 🗄️
         uses: Swatinem/rust-cache@v2
@@ -125,6 +133,9 @@ jobs:
 
       - name: Install Rust 🦀
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Run sccache-cache 🗄️
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Setup Rust Cache 🗄️
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved CI workflow by integrating `sccache` for enhanced caching of Rust compilation, which may lead to faster build times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->